### PR TITLE
Padronizar Controllers (Abstração Nível 2)

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,26 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  console.error(publicErrorObject);
+
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -49,5 +49,3 @@ const database = {
 };
 
 export default database;
-
-//https://github.com/filipedeschamps/clone-tabnews/pull/46

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors.js";
 
 async function query(queryObject) {
   let client;
@@ -8,9 +9,11 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    console.log("\n Erro dentro do catch do database.js:");
-    console.error(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      message: "Erro na conexão com Banco ou na Query.",
+      cause: error,
+    });
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }
@@ -46,3 +49,5 @@ const database = {
 };
 
 export default database;
+
+//https://github.com/filipedeschamps/clone-tabnews/pull/46

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,50 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
     this.name = "InternalServerError";
     this.action = "Entre em contato com o suporte.";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço indisponível no momento.", {
+      cause,
+    });
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponível.";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para este endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.action =
+      "Verifique se o método HTTP enviado é válido para este endpoint.";
+    this.statusCode = 405;
   }
 
   toJSON() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.7",
         "dotenv-expand": "12.0.1",
         "next": "15.2.2",
+        "next-connect": "^1.0.0",
         "node-pg-migrate": "7.9.1",
         "pg": "8.14.0",
         "react": "19.0.0",
@@ -2449,6 +2450,11 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8898,6 +8904,18 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9934,6 +9952,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dotenv": "16.4.7",
     "dotenv-expand": "12.0.1",
     "next": "15.2.2",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.9.1",
     "pg": "8.14.0",
     "react": "19.0.0",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,52 +1,58 @@
+import { createRouter } from "next-connect";
 import migrationRunner from "node-pg-migrate";
-import { resolve } from "path";
+import { resolve } from "node:path";
 import database from "infra/database.js";
+import controller from "infra/controller.js";
 
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
-  if (!allowedMethods.includes(request.method)) {
-    return response.status(405).json({
-      error: `Method "${request.method}" not allowed`,
-    });
-  }
+const router = createRouter();
 
+router.get(getHandler);
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+const defaultMigrationOptions = {
+  dryRun: true,
+  dir: resolve("infra", "migrations"),
+  direction: "up",
+  verbose: true,
+  migrationsTable: "pgmigrations",
+};
+
+async function getHandler(request, response) {
   let dbClient;
 
   try {
     dbClient = await database.getNewClient();
 
-    const defaultMigrationOptions = {
-      dbClient: dbClient,
-      dryRun: true,
-      dir: resolve("infra", "migrations"),
-      direction: "up",
-      verbose: true,
-      migrationsTable: "pgmigrations",
-    };
-
-    if (request.method === "GET") {
-      const pendingMigrations = await migrationRunner(defaultMigrationOptions);
-      return response.status(200).json(pendingMigrations);
-    }
-
-    if (request.method === "POST") {
-      const migratedMigrations = await migrationRunner({
-        ...defaultMigrationOptions,
-        dryRun: false,
-      });
-
-      if (migratedMigrations.length > 0) {
-        return response.status(201).json(migratedMigrations);
-      }
-
-      return response.status(200).json(migratedMigrations);
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
+    const pendingMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+    });
+    return response.status(200).json(pendingMigrations);
   } finally {
-    if (dbClient) {
-      await dbClient.end();
+    await dbClient.end();
+  }
+}
+
+async function postHandler(request, response) {
+  let dbClient;
+
+  try {
+    dbClient = await database.getNewClient();
+
+    const migratedMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+      dryRun: false,
+    });
+
+    if (migratedMigrations.length > 0) {
+      return response.status(201).json(migratedMigrations);
     }
+
+    return response.status(200).json(migratedMigrations);
+  } finally {
+    await dbClient.end();
   }
 }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,52 +1,43 @@
-import database from "infra/database.js";
-import { InternalServerError } from "infra/errors";
+import { createRouter } from "next-connect";
+import database from "infra/database";
+import controller from "infra/controller.js";
 
-class Status {
-  constructor() {
-    // Inicializações necessárias podem ser feitas aqui.
-  }
+const router = createRouter();
 
-  async handleRequest(request, response) {
-    try {
-      //const result = await database.query("SELECT 1 + 1 as sum;");
-      //console.log(result.rows);
+router.get(getHandler);
 
-      // Obtém a data e hora atual, convertendo para o formato ISO 8601.
-      const updatedAt = new Date().toISOString();
+export default router.handler(controller.errorHandlers);
 
-      // Obtém a versão do PostgreSQL.
-      //const databaseVersion = await database.query(`SHOW server_version;`);
+async function getHandler(request, response) {
+  const updatedAt = new Date().toISOString();
 
-      const databaseName = process.env.POSTGRES_DB;
-      const databaseStatus = await database.query({
-        text: `SELECT 
+  const databaseVersionResult = await database.query("SHOW server_version;");
+  const databaseVersionValue = databaseVersionResult.rows[0].server_version;
+
+  const databaseMaxConnectionsResult = await database.query(
+    "SHOW max_connections;",
+  );
+  const databaseMaxConnectionsValue =
+    databaseMaxConnectionsResult.rows[0].max_connections;
+
+  const databaseName = process.env.POSTGRES_DB;
+  const databaseStatus = await database.query({
+    text: `SELECT 
               current_setting('server_version') AS server_version, 
               current_setting('max_connections')::int AS max_connections, 
               (SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1 ) AS opened_connections;`,
 
-        values: [databaseName],
-      });
+    values: [databaseName],
+  });
 
-      response.status(200).json({
-        updated_at: updatedAt,
-        dependencies: {
-          database: {
-            version: databaseStatus.rows[0].server_version,
-            max_connections: databaseStatus.rows[0].max_connections,
-            opened_connections: databaseStatus.rows[0].opened_connections,
-          },
-        },
-      });
-    } catch (error) {
-      const publicErrorObject = new InternalServerError({
-        cause: error,
-      });
-
-      console.log("\n Erro dentro do catch do controller:");
-      console.error(publicErrorObject);
-
-      response.status(500).json(publicErrorObject);
-    }
-  }
+  response.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: databaseStatus.rows[0].server_version,
+        max_connections: databaseStatus.rows[0].max_connections,
+        opened_connections: databaseStatus.rows[0].opened_connections,
+      },
+    },
+  });
 }
-export default new Status().handleRequest;

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -11,14 +11,15 @@ export default router.handler(controller.errorHandlers);
 async function getHandler(request, response) {
   const updatedAt = new Date().toISOString();
 
-  const databaseVersionResult = await database.query("SHOW server_version;");
-  const databaseVersionValue = databaseVersionResult.rows[0].server_version;
+  //const databaseVersionResult = await database.query("SHOW server_version;");
+  //const databaseVersionValue = databaseVersionResult.rows[0].server_version;
 
-  const databaseMaxConnectionsResult = await database.query(
-    "SHOW max_connections;",
-  );
-  const databaseMaxConnectionsValue =
-    databaseMaxConnectionsResult.rows[0].max_connections;
+  //const databaseMaxConnectionsResult = await database.query(
+  //  "SHOW max_connections;",
+  //);
+
+  //const databaseMaxConnectionsValue =
+  //  databaseMaxConnectionsResult.rows[0].max_connections;
 
   const databaseName = process.env.POSTGRES_DB;
   const databaseStatus = await database.query({

--- a/tests/api/v1/status/post.test.js
+++ b/tests/api/v1/status/post.test.js
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------- //
+//                                                                        //
+//                         Testes de Integração                           //
+//                                                                        //
+// ---------------------------------------------------------------------- //
+// Arquivo: post.text.js                                                   //
+// Autor: RodrigoMS                                                       //
+// Data: 30/07/2025                                                      //
+// Descrição: Este arquivo contém os testes de integração para o sistema. //
+// Assegura que todos os módulos funcionem corretamente em conjunto.      //
+// ---------------------------------------------------------------------- //
+
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint.",
+        status_code: 405,
+      });
+
+      // Extrai o corpo da resposta e converte para JSON
+      //const responseBody = await response.json();
+
+      // Verifica se a propriedade 'updated_at' está definida no corpo da resposta
+      //expect(responseBody.updated_at).toBeDefined();
+
+      // Converte a data 'updated_at' para o formato ISOString
+      //const parseUpdateAt = new Date(responseBody.updated_at).toISOString();
+
+      // Verifica se a data no corpo da resposta é igual à data convertida
+      //expect(responseBody.updated_at).toEqual(parseUpdateAt);
+
+      // Verifica se a versão do PostgreSQL é a definida no projeto.
+      //expect(responseBody.dependencies.database.version).toEqual("16.0");
+
+      // Conexões máximas disponíveis pelo ambiente local.
+      //expect(responseBody.dependencies.database.max_connections).toEqual(100);
+
+      // Número de conexões usadas atual ser iguar a 1.
+      //expect(responseBody.dependencies.database.opened_connections).toEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
Aula 39 - Abstração de 1 e 2 nível

1. Padroniza os Controllers dos endpoints /migrations e /status.
2. Adiciona 2 novos erros customizados: MethodNotAllowedError e ServiceError.
3. Faz o nternalServerError aceitar injeção de statusCode
